### PR TITLE
Possible wrong negation instead of comparison

### DIFF
--- a/odbc.c
+++ b/odbc.c
@@ -1349,7 +1349,7 @@ get_connection(term_t tcid, connection **cn)
       return type_error(tcid, "odbc_connection");
     c = ptr;
 
-    if ( !c->magic == CON_MAGIC )
+    if ( c->magic != CON_MAGIC )
       return existence_error(tcid, "odbc_connection");
   } else
   { if ( !PL_get_atom(tcid, &alias) )


### PR DESCRIPTION
Again, same issue, check if indeed an error.

The warning:

```
odbc.c:1352:20: warning: comparison of constant ‘2084746784’ with boolean expression is always false [-Wbool-compare]
     if ( !c->magic == CON_MAGIC )
                    ^
odbc.c:1352:20: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
```
