### PR TITLE
Add ODBC connection pooling.

### DIFF
--- a/odbc.doc
+++ b/odbc.doc
@@ -68,6 +68,18 @@ described here.
 \section{The ODBC layer}
 \label{sec:odbc}
 
+\subsection{Global configuration}
+
+    \predicate{odbc_set_option}{1}{+Property}
+Set global properties for the environment. This must be called before
+calling any other ODBC predicates. Permitted properties currently include
+    \begin{description}
+    \termitem{connection_pooling}{+bool}
+    If true, then enable connection pooling for the entire process. Note
+    that due to limitations of ODBC itself, it is not possible to turn
+    pooling off once enabled.
+    \end{description}
+
 \subsection{Connection management}
 \label{sec:odbc-connections}
 
@@ -111,6 +123,16 @@ requiring the dynamic cursor (which incurs an astounding 20-50x slowdown
 of query execution!!). MARS is a new feature in SQL2k5 apparently, and
 only works if you use the native driver. For the non-native driver,
 specifying that it is enabled will have absolutely no effect.
+
+    \termitem{connection_pool_mode}{+Bool}
+Determines how a connection is chosen from a connection pool if connection
+pooling is on. See odbc_set_option/1 for enabling pooling. Permitted
+values are 'strict' (Only connections that exactly match the connection
+options in the call and the connection attributes set by the application
+are reused. This is the default) and 'relaxed' (Connections with matching
+connection string keywords can be used. Keywords must match, but not all
+connection attributes must match.)
+
 
     \termitem{odbc_version}{+Atom}
 Select the version of the ODBC connection.  Default is \verb$'3.0'$.

--- a/odbc.pl
+++ b/odbc.pl
@@ -66,6 +66,7 @@
             odbc_table_primary_key/3,   % +Conn, ?Table, ?Column
             odbc_table_foreign_key/5,   % +Conn, ?PkTable, ?PkColumn, ?FkTable, ?FkColumn
 
+	    odbc_set_option/1,          % -Option
             odbc_statistics/1,          % -Value
             odbc_debug/1                % +Level
           ]).


### PR DESCRIPTION
This is a proposed patch to turn on ODBC connection pooling (See https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/driver-manager-connection-pooling) 

Unfortunately, you have to turn the feature on before allocating the environment handle, and it's a process-wide setting. And it's impossible to turn off once you turn it on. 

Since it's a setting that supersedes even the environment (let alone the connection) this isn't something that we can just add into the connection string or options for odbc_connect/3. This leaves us in an awkward position, since the most primitive object we have to represent ODBC connectivity in SWI-Prolog is the connection handle.

Since connection pooling can make subtle logical changes to the way the database connection works, I don't want to just turn it on for everyone. Instead I've added a new predicate to configure even-higher-level settings than the connection: odbc_set_option